### PR TITLE
ApiResult の定義を修正

### DIFF
--- a/tools/api.ts
+++ b/tools/api.ts
@@ -3,7 +3,7 @@ import * as Types from './types';
 // APIとの通信周りの関数と型たち
 
 interface ApiResult {
-    succeeded: string,
+    succeeded: boolean,     // 処理に成功すると真
 };
 type GeneralId = string;
 export type UserId = GeneralId;


### PR DESCRIPTION
Manki API から受信される JSON に含まれる succeeded の型は boolean です