### PR TITLE
import のパスをプロジェクトルートからの相対パスに変更

### DIFF
--- a/component/hooks/usepageLoading.tsx
+++ b/component/hooks/usepageLoading.tsx
@@ -1,5 +1,5 @@
-import { useContext } from "react";
-import { LoadingContext } from "../../pages/_app";
+import React, { createContext, useContext } from "react";
+import { LoadingContext } from "pages/_app";
 
 export type usePageLoadingType = {
     isShow: boolean;

--- a/component/map/CircleMap.tsx
+++ b/component/map/CircleMap.tsx
@@ -1,7 +1,7 @@
 import { LatLng } from "leaflet";
-import React from "react";
+import React, { SetStateAction, useState } from "react";
 import { Circle, MapContainer, TileLayer, useMapEvents } from "react-leaflet";
-import { useModal } from "../hooks/useModal";
+import { useModal } from "component/hooks/useModal";
 
 interface LatLngRadius {
     position: LatLng,

--- a/component/map/DestinationMap.tsx
+++ b/component/map/DestinationMap.tsx
@@ -1,8 +1,8 @@
 import { LatLng } from "leaflet";
 import React, { SetStateAction } from "react";
 import { MapContainer, Marker, TileLayer, useMapEvents, Circle, Polyline } from "react-leaflet";
-import { LatLangRadius } from "../../pages/Desitination";
-import { relayPoint } from "../../pages/Desitination";
+import { LatLangRadius } from "pages/Desitination";
+import { relayPoint } from "pages/Desitination";
 import L from 'leaflet';
 
 const position = new LatLng(38.72311671577611, 141.0346841825174);

--- a/pages/AllCarWatch.tsx
+++ b/pages/AllCarWatch.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useContext } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { useModal } from "../component/hooks/useModal";
-import { AdminIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { AdminIdContext } from "pages/_app";
 
 const getCarInfoUrl = 'http://sazasub.kohga.local/getCarInfo';
 

--- a/pages/CarManager.tsx
+++ b/pages/CarManager.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useContext } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { useModal } from "../component/hooks/useModal";
-import { AdminIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { AdminIdContext } from "pages/_app";
 
 const EndAdminUrl = 'http://sazasub.kohga.local/terminateAdmin';
 

--- a/pages/CarMenu.tsx
+++ b/pages/CarMenu.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { useModal } from "../component/hooks/useModal";
-import { UserIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { UserIdContext } from "pages/_app";
 
 const CarUseCheckUrl = 'http://sazasub.kohga.local/isAcceptable';
 const EndPageUrl = 'http://sazasub.kohga.local/terminate';

--- a/pages/CarWatch.tsx
+++ b/pages/CarWatch.tsx
@@ -3,9 +3,9 @@ import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import { useContext, useEffect, useState } from "react";
-import { useModal } from "../component/hooks/useModal";
-import { UserIdContext } from "./_app";
-import _BaseButton from "../component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { UserIdContext } from "pages/_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
 
 
 interface ReqMonitorCarData {

--- a/pages/Desitination.tsx
+++ b/pages/Desitination.tsx
@@ -2,11 +2,11 @@ import { useRouter } from "next/router";
 import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import React, { useState, SetStateAction, useContext, useEffect } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
+import _BaseButton from "component/atoms/button/_BaseButton";
 import { LatLng } from "leaflet";
-import { CheckBoxForm } from "../component/atoms/checkbox/checkBoxForm";
-import { LoadingContext, UserIdContext } from "./_app";
-import { useModal } from "../component/hooks/useModal";
+import { CheckBoxForm } from "component/atoms/checkbox/checkBoxForm";
+import { LoadingContext, UserIdContext } from "pages/_app";
+import { useModal } from "component/hooks/useModal";
 
 
 

--- a/pages/ExistsRoute.tsx
+++ b/pages/ExistsRoute.tsx
@@ -2,10 +2,10 @@ import { LatLng } from "leaflet";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { useModal } from "../component/hooks/useModal";
-import { DynamicCarWatchMap } from "./CarWatch";
-import { UserIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { DynamicCarWatchMap } from "pages/CarWatch";
+import { UserIdContext } from "pages/_app";
 
 interface ReqRouteData {
     userId: string;

--- a/pages/PathOkManager.tsx
+++ b/pages/PathOkManager.tsx
@@ -3,10 +3,10 @@ import { NextPage } from "next";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
 import React, { useContext, useState } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { CheckBoxForm } from "../component/atoms/checkbox/checkBoxForm";
-import { useModal } from "../component/hooks/useModal";
-import { AdminIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { CheckBoxForm } from "component/atoms/checkbox/checkBoxForm";
+import { useModal } from "component/hooks/useModal";
+import { AdminIdContext } from "pages/_app";
 
 const addPassableUrl = 'http://sazasub.kohga.local/addPassable';
 const reqPassAdminUrl = 'http://sazasub.kohga.local/reqPassAdmin';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,9 @@
-import '../styles/styles.scss';
+import 'styles/styles.scss';
 import "leaflet/dist/leaflet.css";
 import type { AppProps } from 'next/app';
 import React, { createContext, useState } from 'react';
-import { PageLoading } from '../component/atoms/pageLoading';
-import { usePageLoadingType } from '../component/hooks/usepageLoading';
+import { PageLoading } from 'component/atoms/pageLoading';
+import { usePageLoadingType } from 'component/hooks/usepageLoading';
 
 
 export const UserIdContext = createContext({} as {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,9 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { useContext } from "react";
-import _BaseButton from "../component/atoms/button/_BaseButton";
-import { useModal } from "../component/hooks/useModal";
-import { UserIdContext } from "./_app";
+import _BaseButton from "component/atoms/button/_BaseButton";
+import { useModal } from "component/hooks/useModal";
+import { UserIdContext } from "pages/_app";
 const CreateUserUrl = 'http://sazasub.kohga.local/createUser';
 
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { useContext, useState } from "react";
-import { useModal } from "../component/hooks/useModal";
-import { AdminIdContext, LoadingContext } from "./_app";
+import { useModal } from "component/hooks/useModal";
+import { AdminIdContext, LoadingContext } from "pages/_app";
 
 interface ReqAdmin {
     adminName: string,

--- a/pages/passwd.tsx
+++ b/pages/passwd.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useContext, useEffect, useState } from "react";
-import { useModal } from "../component/hooks/useModal";
-import { AdminIdContext } from "./_app";
+import { useModal } from "component/hooks/useModal";
+import { AdminIdContext } from "pages/_app";
 
 interface ReqChangePasswd {
     AdminId: string,

--- a/tools/api.ts
+++ b/tools/api.ts
@@ -1,4 +1,4 @@
-import * as Types from './types';
+import * as Types from 'tools/types';
 
 // APIとの通信周りの関数と型たち
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "./"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
このようにすることで、そのファイルがどのようなディレクトリ階層にあっても、依存しているファイルを簡明に把握できるようになります